### PR TITLE
Fix cyclic offset for more than 2 chains

### DIFF
--- a/colabfold/batch.py
+++ b/colabfold/batch.py
@@ -417,13 +417,14 @@ def predict_structure(
                         if is_complex:
                             logger.info("Applying multimer cyclic complex offset with bugfix")
                             idx = input_features["residue_index"]
-                            idx = index_extend(idx, sequences_lengths[1], sequences_lengths[0])
+                            complex_length = sum(sequences_lengths[:-1])
+                            idx = index_extend(idx, sequences_lengths[-1], complex_length)
                             offset = np.array(idx[:,None] - idx[None,:])
                             logger.info("bugfix mulitimer cyclic complex offset")
-                            c_offset = cyclic_offset(sequences_lengths[1])
+                            c_offset = cyclic_offset(sequences_lengths[-1])
                             input_features["offset"] = offset
                             logger.info(f"\n{c_offset}\n")
-                            offset[sequences_lengths[0]:,sequences_lengths[0]:] = c_offset
+                            offset[complex_length:,complex_length:] = c_offset
                             input_features["offset"] = offset
                         else:
                             logger.info("Applying default cyclic offset with bugfix")
@@ -445,12 +446,13 @@ def predict_structure(
                         if is_complex:
                             logger.info("Applying cyclic complex offset with bugfix")
                             idx = input_features["residue_index"][0]
-                            idx = index_extend(idx, sequences_lengths[1], sequences_lengths[0])
+                            complex_length = sum(sequences_lengths[:-1])
+                            idx = index_extend(idx, sequences_lengths[-1], complex_length)
                             offset = np.array(idx[:,None] - idx[None,:])
                             logger.info("bugfix cyclic complex offset")
-                            c_offset = cyclic_offset(sequences_lengths[1])
+                            c_offset = cyclic_offset(sequences_lengths[-1])
                             logger.info(f"\n{c_offset}\n")
-                            offset[sequences_lengths[0]:,sequences_lengths[0]:] = c_offset
+                            offset[complex_length:,complex_length:] = c_offset
                             input_features["offset"] = np.tile(offset[None],(r,1,1))
                         else:
                             logger.info("Applying default cyclic offset with bugfix")


### PR DESCRIPTION
Hi, thank you for supporting cyclic peptide prediction!

When I tried to predict cyclic peptide (10 aa) interacting with multi-chain protein complex (chain A: 92 aa + chain B: 494 aa), an error occurred:

```
Traceback (most recent call last):
  File "/app/localcolabfold/colabfold-conda/bin/colabfold_batch", line 8, in <module>
    sys.exit(main())
  File "/app/localcolabfold/colabfold-conda/lib/python3.10/site-packages/colabfold/batch.py", line 1957, in main
    run(
  File "/app/localcolabfold/colabfold-conda/lib/python3.10/site-packages/colabfold/batch.py", line 1470, in run
    results = predict_structure(
  File "/app/localcolabfold/colabfold-conda/lib/python3.10/site-packages/colabfold/batch.py", line 428, in predict_structure
    offset[sequences_lengths[0]:,sequences_lengths[0]:] = c_offset
ValueError: could not broadcast input array from shape (494,494) into shape (504,504)
```

I think that may because the code only supports single-chain protein with peptide. So I modified the code to fix it.

Could you please review the code and help me to check whether it worked correctly. Thanks!

